### PR TITLE
Added Bridgecrew OSS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,6 @@
 
 - [Yor](https://yor.io/1.Welcome/welcome.html) - Yor is an open-source tool that helps add informative and consistent tags across infrastructure-as-code frameworks such as Terraform, CloudFormation, and Serverless. [Edit on GitHub](https://github.com/bridgecrewio/yor/tree/main/docs).
 
-- [TerraGoat](https://github.com/bridgecrewio/terragoat) - TerraGoat is a learning and training project that demonstrates how common configuration errors can find their way into production cloud environments.
-
 <a name="confluentinc-open-source-documentations"/>
 
 ## Confluent Inc Open Source Documentations


### PR DESCRIPTION
Added links for 2 projects:
- Yor
- TerraGoat

I couldn't find the documentation for TerraGoat, so I've added the GitHub Repo link for it.

#64 